### PR TITLE
Update manifests to use default namespace by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,15 @@ that can be used to assemble a NATS Streaming cluster on top of a Kubernetes clu
 To install the NATS Streaming Operator on your cluster:
 
 ```sh
-# Install latest version of NATS Operator on nats-io namespace
-kubectl -n nats-io apply -f https://raw.githubusercontent.com/nats-io/nats-operator/master/example/deployment-rbac.yaml
+# Install NATS Operator on default namespace
+$ kubectl apply -f https://raw.githubusercontent.com/nats-io/nats-operator/master/deploy/default-rbac.yaml
 
-# Installing the NATS Streaming Operator on nats-io namespace
-kubectl -n nats-io apply -f https://raw.githubusercontent.com/nats-io/nats-streaming-operator/master/deploy/deployment-rbac.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/nats-io/nats-operator/master/deploy/deployment.yaml
+
+# Install NATS Streaming Operator on default namespace
+$ kubectl apply -f https://raw.githubusercontent.com/nats-io/nats-streaming-operator/master/deploy/default-rbac.yaml
+
+$ kubectl apply -f https://raw.githubusercontent.com/nats-io/nats-streaming-operator/master/deploy/deployment.yaml
 ```
 
 You will then be able to confirm that there is a new `natsstreamingclusters.streaming.nats.io` CRD registered:

--- a/deploy/default-rbac.yaml
+++ b/deploy/default-rbac.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nats-streaming-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nats-streaming-operator-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nats-streaming-operator
+subjects:
+- kind: ServiceAccount
+  name: nats-streaming-operator
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nats-streaming-operator
+rules:
+# Allow creating CRDs
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs: ["*"]
+
+# Allow all actions on NatsClusters
+- apiGroups:
+  - nats.io
+  resources:
+  - natsclusters
+  - natsserviceroles
+  verbs: ["*"]
+
+# Allow all actions on NatsStreamingClusters
+- apiGroups:
+  - streaming.nats.io
+  resources:
+  - natsstreamingclusters
+  verbs: ["*"]
+
+# Allow actions on basic Kubernetes objects
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - secrets
+  - pods
+  - services
+  - serviceaccounts
+  - serviceaccounts/token
+  - endpoints
+  - events
+  verbs: ["*"]

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -18,7 +18,7 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: nats-streaming-operator
-  namespace: nats-io
+  namespace: default
 spec:
   replicas: 1
   selector:

--- a/test/operator/deploy.sh
+++ b/test/operator/deploy.sh
@@ -17,7 +17,8 @@ kubectl get crd | grep natscluster && {
 }
 
 # Deploy the NATS cluster manifest with RBAC enabled
-kubectl -n nats-io apply -f https://raw.githubusercontent.com/nats-io/nats-operator/master/example/deployment-rbac.yaml
+kubectl apply -f https://raw.githubusercontent.com/nats-io/nats-operator/master/deploy/default-rbac.yaml
+kubectl apply -f https://raw.githubusercontent.com/nats-io/nats-operator/master/deploy/deployment.yaml
 
 # Wait until the CRD is ready
 attempts=0
@@ -34,7 +35,9 @@ until kubectl get crd natsclusters.nats.io -o yaml | grep InitialNamesAccepted; 
 done
 
 # Deploy the NATS Streaming CRD with RBAC enabled
-kubectl apply -f deploy/deployment-rbac.yaml
+kubectl apply -f deploy/default-rbac.yaml
+
+kubectl apply -f deploy/deployment.yaml
 
 # Wait until the CRD is ready
 attempts=0
@@ -51,15 +54,15 @@ until kubectl get crd natsstreamingclusters.streaming.nats.io -o yaml | grep Ini
 done
 
 # Deploy an example manifest and wait for pods to appear
-kubectl -n nats-io apply -f deploy/examples/example-nats-cluster.yaml
+kubectl apply -f deploy/examples/example-nats-cluster.yaml
 
 # Wait until 3 pods appear
 attempts=0
-until kubectl -n nats-io get pods | grep -v operator | grep nats | grep Running | wc -l | grep 3; do
+until kubectl get pods | grep -v operator | grep nats | grep Running | wc -l | grep 3; do
     if [[ attempts -eq 60 ]]; then
         echo "Gave up waiting for NatsCluster to be ready..."
-        kubectl -n nats-io logs deployment/nats-operator
-        kubectl -n nats-io logs -l nats_cluster=example-nats
+        kubectl logs deployment/nats-operator
+        kubectl logs -l nats_cluster=example-nats
         exit 1
     fi
 
@@ -69,19 +72,19 @@ until kubectl -n nats-io get pods | grep -v operator | grep nats | grep Running 
 done
 
 # Show output to confirm.
-kubectl -n nats-io logs -l nats_cluster=example-nats
+kubectl logs -l nats_cluster=example-nats
 
 # Next, deploy the NATS Streaming Cluster
-kubectl -n nats-io apply -f deploy/examples/example-stan-cluster.yaml
+kubectl apply -f deploy/examples/example-stan-cluster.yaml
 
 # Wait until 3 pods appear
 attempts=0
-until kubectl -n nats-io get pods | grep -v operator | grep stan | wc -l | grep 3; do
+until kubectl get pods | grep -v operator | grep stan | wc -l | grep 3; do
     if [[ attempts -eq 120 ]]; then
         echo "Gave up waiting for NatsStreamingCluster to be ready..."
-        kubectl -n nats-io get pods
-        kubectl -n nats-io logs deployment/nats-streaming-operator
-        kubectl -n nats-io logs -l stan_cluster=example-stan
+        kubectl get pods
+        kubectl logs deployment/nats-streaming-operator
+        kubectl logs -l stan_cluster=example-stan
         exit 1
     fi
 


### PR DESCRIPTION
Let the manifests use default namespace since that is more common, can still be manually modified to use other namespace or via `kubectl -n nats-io` for example.
Fixes #5 and #3 

Signed-off-by: Waldemar Quevedo <wally@synadia.com>