### PR TITLE
Support SQL store and custom Pod Spec

### DIFF
--- a/deploy/examples/example-stan-cluster-db.yaml
+++ b/deploy/examples/example-stan-cluster-db.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: "streaming.nats.io/v1alpha1"
+kind: "NatsStreamingCluster"
+metadata:
+  name: "example-stan-db"
+spec:
+  natsSvc: "example-nats"
+
+  # Explicitly set that the managed NATS Streaming instance
+  # will be using an SQL storage, to ensure that only a single
+  # instance is available.
+  store: SQL
+
+  # In order to use DB store support, it is needed to include
+  # the credentials as a secret on a mounted file.
+  configFile: "/etc/stan/config/secret.conf"
+
+  # Define Pod Spec
+  template:
+    spec:
+      volumes:
+      - name: stan-secret
+        secret:
+          secretName: stan-secret
+      containers:
+        - name: nats-streaming
+          volumeMounts:
+          - mountPath: /etc/stan/config
+            name: stan-secret
+            readOnly: true

--- a/pkg/apis/streaming/v1alpha1/register.go
+++ b/pkg/apis/streaming/v1alpha1/register.go
@@ -14,8 +14,6 @@
 package v1alpha1
 
 import (
-	sdkK8sutil "github.com/operator-framework/operator-sdk/pkg/util/k8sutil"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -32,10 +30,6 @@ var (
 	// SchemeGroupVersion is the group version used to register these objects.
 	SchemeGroupVersion = schema.GroupVersion{Group: groupName, Version: version}
 )
-
-func init() {
-	sdkK8sutil.AddToSDKScheme(AddToScheme)
-}
 
 // addKnownTypes adds the set of types defined in this package to the supplied scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {

--- a/pkg/apis/streaming/v1alpha1/types.go
+++ b/pkg/apis/streaming/v1alpha1/types.go
@@ -14,6 +14,7 @@
 package v1alpha1
 
 import (
+	k8scorev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -51,8 +52,17 @@ type NatsStreamingClusterSpec struct {
 	// same namespace as the NATS Operator.
 	NatsService string `json:"natsSvc"`
 
-	// Config is the server configuration
+	// Config is the server configuration.
 	Config *ServerConfig `json:"config,omitempty"`
+
+	// StoreType is the type of storage.
+	StoreType string `json:"store,omitempty"`
+
+	// ConfigFile is the optional configuration file for the server.
+	ConfigFile string `json:"configFile,omitempty"`
+
+	// PodTemplate is the optional template to use for the pods.
+	PodTemplate *k8scorev1.PodTemplateSpec `json:"template,omitempty"`
 }
 
 // ServerConfig is the configuration for the server.

--- a/pkg/apis/streaming/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/streaming/v1alpha1/zz_generated.deepcopy.go
@@ -19,6 +19,7 @@
 package v1alpha1
 
 import (
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -90,6 +91,11 @@ func (in *NatsStreamingClusterSpec) DeepCopyInto(out *NatsStreamingClusterSpec) 
 		in, out := &in.Config, &out.Config
 		*out = new(ServerConfig)
 		**out = **in
+	}
+	if in.PodTemplate != nil {
+		in, out := &in.PodTemplate, &out.PodTemplate
+		*out = new(v1.PodTemplateSpec)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/test/operator/basic_test.go
+++ b/test/operator/basic_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nats-io/nats-streaming-operator/internal/operator"
 	stanv1alpha1 "github.com/nats-io/nats-streaming-operator/pkg/apis/streaming/v1alpha1"
 	stancrdclient "github.com/nats-io/nats-streaming-operator/pkg/client/v1alpha1"
+	k8scorev1 "k8s.io/api/core/v1"
 	k8scrdclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
@@ -149,6 +150,97 @@ func TestCreateClusterWithDebugFlags(t *testing.T) {
 			expectedFlag = "--cluster_raft_logging"
 			if !strings.Contains(s, expectedFlag) {
 				return fmt.Errorf("Does not contain %s flag", expectedFlag)
+			}
+		}
+
+		got := len(result.Items)
+		if got < 1 {
+			return fmt.Errorf("Not enough pods, got: %v", got)
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestCreateClusterWithCustomTemplate(t *testing.T) {
+	kc, err := newKubeClients()
+	if err != nil {
+		t.Fatal(err)
+	}
+	controller := operator.NewController(nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	go controller.Run(ctx)
+
+	name := "stan-cluster-custom-test"
+	cluster := &stanv1alpha1.NatsStreamingCluster{
+		TypeMeta: k8smetav1.TypeMeta{
+			Kind:       "NatsStreamingCluster",
+			APIVersion: stanv1alpha1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: k8smetav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Spec: stanv1alpha1.NatsStreamingClusterSpec{
+			Size:        3,
+			NatsService: "example-nats",
+			StoreType:   "SQL",
+			ConfigFile:  "/etc/streaming/config/stan.conf",
+			Config: &stanv1alpha1.ServerConfig{
+				Debug:       true,
+				Trace:       true,
+				RaftLogging: true,
+			},
+			PodTemplate: &k8scorev1.PodTemplateSpec{
+				Spec: k8scorev1.PodSpec{
+					RestartPolicy: k8scorev1.RestartPolicyNever,
+				},
+			},
+		},
+	}
+	_, err = kc.stan.StreamingV1alpha1().NatsStreamingClusters("default").Create(cluster)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		err := kc.stan.StreamingV1alpha1().NatsStreamingClusters("default").Delete(name, &k8smetav1.DeleteOptions{})
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	opts := k8smetav1.ListOptions{
+		LabelSelector: k8slabels.SelectorFromSet(map[string]string{
+			"app":          "nats-streaming",
+			"stan_cluster": name,
+		}).String(),
+	}
+
+	err = waitFor(ctx, func() error {
+		result, err := kc.core.Pods("default").List(opts)
+		if err != nil {
+			return err
+		}
+		for _, item := range result.Items {
+			s := strings.Join(item.Spec.Containers[0].Command, " ")
+
+			expectedFlag := "-sc"
+			if !strings.Contains(s, expectedFlag) {
+				return fmt.Errorf("Does not contain %s flag", expectedFlag)
+			}
+
+			expectedFlag = "-store"
+			if !strings.Contains(s, expectedFlag) {
+				return fmt.Errorf("Does not contain %s flag", expectedFlag)
+			}
+
+			if item.Spec.RestartPolicy != k8scorev1.RestartPolicyNever {
+				return fmt.Errorf("Custom restart policy was not set, got %s", item.Spec.RestartPolicy)
 			}
 		}
 


### PR DESCRIPTION
This makes it possible to set store type to be SQL and ensure that the operator creates only a single instance at a time for the specified cluster.  In order to pass the credentials to the database, a secret has to be used and be mounted as part of the NATS Streaming container that will be connecting to the DB:

```yaml
---
apiVersion: "streaming.nats.io/v1alpha1"
kind: "NatsStreamingCluster"
metadata:
  name: "example-stan-db"
spec:
  natsSvc: "example-nats"

  # Explicitly set that the managed NATS Streaming instance
  # will be using an SQL storage, to ensure that only a single
  # instance is available.
  store: SQL

  # In order to use DB store support, it is needed to include
  # the credentials as a secret on a mounted file.
  configFile: "/etc/stan/config/secret.conf"

  # Define Pod Spec
  template:
    spec:
      volumes:
      - name: stan-secret
        secret:
          secretName: stan-secret
      containers:
        - name: nats-streaming
          volumeMounts:
          - mountPath: /etc/stan/config
            name: stan-secret
            readOnly: true
```

The secret configuration file should be in regular NATS Streaming config format:

```
echo '
streaming: {
  sql: {
    driver: "postgres"
    source: "postgres://exampleuser:notasecret@stan.asdfkljh.us-west-2.rds.amazonaws.com/stan?sslmode=disable"
  }
}
' > secret.conf

$ kubectl create secret generic stan-secret --from-file secret.conf
```

Fixes #10 