### PR TITLE
Bump deployment.yaml apiVersion to apps/v1

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -14,7 +14,7 @@ spec:
   scope: Namespaced
   version: v1alpha1
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nats-streaming-operator


### PR DESCRIPTION
Resolve https://github.com/nats-io/nats-streaming-operator/issues/53, by bumping the `apiVersion` of the operator deployment. 

The reason for this change if [Kubernetes v1.16.0 deprecated](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) the apps/v1beta2 library. 