### PR TITLE
correctly bind cluster operator role to service account

### DIFF
--- a/helm/nats-streaming-operator/templates/rbac.yaml
+++ b/helm/nats-streaming-operator/templates/rbac.yaml
@@ -15,7 +15,11 @@ metadata:
   name: nats-streaming-operator-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
+{{- if .Values.clusterScoped }}
   kind: ClusterRole
+{{- else }}
+  kind: Role
+{{- end }}
   name: nats-streaming-operator
 subjects:
 - kind: ServiceAccount


### PR DESCRIPTION
I am running the NATS streaming operator with the default `clusterScoped: false` in a namespace in a test cluster whilst we evaluate it internally.
Currently it does not map the role binding correctly, and the operator fails to start with the below error. This patch fixes it.

```
natsstreamingclusters.streaming.nats.io is forbidden: User "system:serviceaccount:incubator:nats-streaming-operator" cannot list resource "natsstreamingclusters" in API group "streaming.nats.io" in the namespace "incubator": RBAC:clusterrole.rbac.authorization.k8s.io "nats-streaming-operator" not found    
```