### PR TITLE
Permission required for OpenShift 3.11 Cluster

### DIFF
--- a/deploy/default-rbac.yaml
+++ b/deploy/default-rbac.yaml
@@ -42,6 +42,7 @@ rules:
   - streaming.nats.io
   resources:
   - natsstreamingclusters
+  - natsstreamingclusters/finalizers
   verbs: ["*"]
 
 # Allow actions on basic Kubernetes objects


### PR DESCRIPTION
Without that setting the operator threw an error when creating the pods.