### PR TITLE
readme update: bumping nats-operator version. fixes #71

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ To install the NATS Streaming Operator on your cluster:
 
 ```sh
 # Install NATS Operator on default namespace
-$ kubectl apply -f https://github.com/nats-io/nats-operator/releases/download/v0.5.0/00-prereqs.yaml
-$ kubectl apply -f https://github.com/nats-io/nats-operator/releases/download/v0.5.0/10-deployment.yaml
+$ kubectl apply -f https://github.com/nats-io/nats-operator/releases/download/v0.7.2/00-prereqs.yaml
+$ kubectl apply -f https://github.com/nats-io/nats-operator/releases/download/v0.7.2/10-deployment.yaml
 
 # Install NATS Streaming Operator on default namespace
 $ kubectl apply -f https://raw.githubusercontent.com/nats-io/nats-streaming-operator/master/deploy/default-rbac.yaml


### PR DESCRIPTION
Just bumping nats-operator version from README.md to the latest nats-operator version ATM (0.7.2).

>  Notice that it will constantly become outdated. Maybe a link to the latest version would be better but I couldn't realize which URL to use. For now, maybe this is ok just to avoid confusion adopting an old version of nats-operator.

Fixes #71 .