### PR TITLE
workaround issue #61 - adding missing configs to all examples of cluster mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ metadata:
 spec:
   size: 3
   natsSvc: "example-nats"
+  config: {}
 ' | kubectl apply -f -
 ```
 

--- a/deploy/examples/example-stan-cluster.yaml
+++ b/deploy/examples/example-stan-cluster.yaml
@@ -15,3 +15,5 @@ spec:
   # Service to which NATS Streaming Cluster nodes will connect.
   # 
   natsSvc: "example-nats"
+
+  config: {}

--- a/test/operator/basic_test.go
+++ b/test/operator/basic_test.go
@@ -43,6 +43,7 @@ func TestCreateCluster(t *testing.T) {
 		Spec: stanv1alpha1.NatsStreamingClusterSpec{
 			Size:        3,
 			NatsService: "example-nats",
+			Config:      &stanv1alpha1.ServerConfig{},
 		},
 	}
 	_, err = kc.stan.StreamingV1alpha1().NatsStreamingClusters("default").Create(cluster)


### PR DESCRIPTION
According to #61 , if you have a `spec.size > 1` and you're using a file store, if you do not define a `spec.config`, then the operator  controller will fail to define the correct `cluster_node_id` for the CLI command of the container. IMHO the best fix is to change that logic in order to allow empty configs to just work by setting the correct `cluster_node_id` anyways. But for now, docs should at least not mislead users to this "misconfiguration". 