### PR TITLE
Reconcile changes to the nats streaming server image string

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ spec:
 To build the `nats-streaming-operator` Docker image:
 
 ```sh
-$ docker build . -f docker/operator/Dockerfile -t <image>:<tag> .
+$ docker build -f docker/operator/Dockerfile -t <image>:<tag> .
 ```
 
 You'll need Docker `17.06.0-ce` or higher.

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,11 @@ k8s.io/apiextensions-apiserver v0.0.0-20190320070711-2af94a2a482f h1:MfV9UCbLKKn
 k8s.io/apiextensions-apiserver v0.0.0-20190320070711-2af94a2a482f/go.mod h1:IxkesAMoaCRoLrPJdZNZUQp9NfZnzqaVzLhb2VEQzXE=
 k8s.io/apimachinery v0.0.0-20190320104356-82cbdc1b6ac2 h1:kAl8fP8Gk3mJ4hZBQOkQ1HkrD1i5n22S3ZKlVGTJsBA=
 k8s.io/apimachinery v0.0.0-20190320104356-82cbdc1b6ac2/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
+k8s.io/apimachinery v0.18.6 h1:RtFHnfGNfd1N0LeSrKCUznz5xtUP1elRGvHJbL3Ntag=
+k8s.io/client-go v1.5.1 h1:XaX/lo2/u3/pmFau8HN+sB5C/b4dc4Dmm2eXjBH4p1E=
 k8s.io/client-go v10.0.0+incompatible h1:F1IqCqw7oMBzDkqlcBymRq1450wD0eNqLE9jzUrIi34=
 k8s.io/client-go v10.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
+k8s.io/client-go v11.0.0+incompatible h1:LBbX2+lOwY9flffWlJM7f1Ct8V2SRNiMRDFeiwnJo9o=
 k8s.io/klog v0.2.0 h1:0ElL0OHzF3N+OhoJTL0uca20SxtYt4X4+bzHeqrB83c=
 k8s.io/klog v0.2.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/kube-openapi v0.0.0-20190320154901-5e45bb682580 h1:fq0ZXW/BAIFZH+dazlups6JTVdwzRo5d9riFA103yuQ=

--- a/internal/operator/constants.go
+++ b/internal/operator/constants.go
@@ -22,7 +22,7 @@ const (
 	// DefaultNATSStreamingImage is the default image
 	// of NATS Streaming that will be used, meant to be
 	// the latest release available.
-	DefaultNATSStreamingImage = "nats-streaming:0.16.2"
+	DefaultNATSStreamingImage = "nats-streaming:0.18.0"
 
 	// DefaultNATSStreamingClusterSize is the default size
 	// for the cluster.  Clustering is done via Raft so

--- a/internal/operator/controller.go
+++ b/internal/operator/controller.go
@@ -427,7 +427,7 @@ func (c *Controller) createPodFrom(o *stanv1alpha1.NatsStreamingCluster, pod *k8
 	newPod := newStanPod(o)
 	newPod.Name = pod.Name
 	container := stanContainer(o, newPod)
-	copy(container.Command, pod.Spec.Containers[0].Command)
+	container.Command = stanContainerCmd(o, pod)
 
 	if len(newPod.Spec.Containers) >= 1 {
 		newPod.Spec.Containers[0] = container

--- a/internal/operator/controller.go
+++ b/internal/operator/controller.go
@@ -355,12 +355,17 @@ func (c *Controller) reconcilePodTemplate(o *stanv1alpha1.NatsStreamingCluster) 
 		desiredImage = DefaultNATSStreamingImage
 	}
 
-	desiredAnnotations := o.Spec.PodTemplate.GetObjectMeta().GetAnnotations()
+	var desiredAnnotations map[string]string
+	podTemplate := o.Spec.PodTemplate
+	if podTemplate != nil {
+		desiredAnnotations = podTemplate.GetObjectMeta().GetAnnotations()
+	}
+
 	for _, pod := range pods {
 		currentImage := pod.Spec.Containers[0].Image
 		currentAnnotations := pod.GetObjectMeta().GetAnnotations()
 		delete(currentAnnotations, "kubernetes.io/psp") // Ignore k8s auto-applied annotations
-		if desiredImage != currentImage || !reflect.DeepEqual(desiredAnnotations, currentAnnotations) {
+		if desiredImage != currentImage || (desiredAnnotations != nil && !reflect.DeepEqual(desiredAnnotations, currentAnnotations)) {
 			if desiredImage != currentImage {
 				log.Infof("Reconciling image '%s' in pod '%s/%s' with '%s'", currentImage, o.Namespace, pod.ObjectMeta.Name, desiredImage)
 			} else {

--- a/pkg/apis/streaming/v1alpha1/types.go
+++ b/pkg/apis/streaming/v1alpha1/types.go
@@ -43,8 +43,8 @@ type NatsStreamingClusterSpec struct {
 	// Size is the number of nodes in the NATS Streaming cluster.
 	Size int32 `json:"size"`
 
-	// Version is the version of NATS Streaming that is being used.
-	// By default it will be the latest version.
+	// Image is the version of NATS Streaming that is being used.
+	// By default it will be set to the latest version.
 	Image string `json:"image"`
 
 	// NatsService is the Kubernetes service to which the NATS


### PR DESCRIPTION
This will allow changes in the NatsStreamingCluster image
string to get propagated to the managed stan pods.

It does this by rebooting the pods one by one. Never moving
on to the next one until the current one has come back up to
not cause an outage.

It also updates the default NATS Streaming server version to
the latest released 0.18.0.

Will also reconcile changes in annotations in order to handle the use case described in #74 .

Closes #74 