### PR TITLE
Filter out additional annotations when comparing to CR

### DIFF
--- a/internal/operator/controller.go
+++ b/internal/operator/controller.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/signal"
 	"reflect"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -365,6 +366,11 @@ func (c *Controller) reconcilePodTemplate(o *stanv1alpha1.NatsStreamingCluster) 
 		currentImage := pod.Spec.Containers[0].Image
 		currentAnnotations := pod.GetObjectMeta().GetAnnotations()
 		delete(currentAnnotations, "kubernetes.io/psp") // Ignore k8s auto-applied annotations
+		for k, _ := range currentAnnotations {
+			if strings.HasPrefix(k, "cni.projectcalico.org/") {
+				delete(currentAnnotations, k)
+			}
+		}
 		if desiredImage != currentImage || (desiredAnnotations != nil && !reflect.DeepEqual(desiredAnnotations, currentAnnotations)) {
 			if desiredImage != currentImage {
 				log.Infof("Reconciling image '%s' in pod '%s/%s' with '%s'", currentImage, o.Namespace, pod.ObjectMeta.Name, desiredImage)


### PR DESCRIPTION
The operator will compare the annotations the CR is configured with
with the annotations of the deployed pod. If these are different, it will 
re-deploy the pod. On some implementations of kubernetes 1.19, it adds
additional automatic annotations for cni.projectcalico.org/*
that the CR will not contain. If these are not filtered out
before the map slice comparison, then the operator will always
think the annotations are different resulting in a never-ending
loop of restarting the stan pods.